### PR TITLE
Fix recover/recoverWith MatchError if partial function is not satisfied and handle exception within it

### DIFF
--- a/future-scala/pom.xml
+++ b/future-scala/pom.xml
@@ -21,6 +21,12 @@
 			<artifactId>scala-library</artifactId>
 			<version>2.12.2</version>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/future-scala/src/test/scala/io/trane/future/scala/ExceptionFutureTest.scala
+++ b/future-scala/src/test/scala/io/trane/future/scala/ExceptionFutureTest.scala
@@ -1,0 +1,60 @@
+package io.trane.future.scala
+
+import scala.concurrent.duration.Duration
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ExceptionFutureTest {
+  private def get[T](future: Future[T]): T = Await.result(future, Duration.Zero)
+
+  val ex = new TestException
+
+  /*** recover ***/
+
+  @Test
+  def recoverAll(): Unit = {
+    val future = Future.failed(ex).recover {
+      case t: Throwable =>
+        assertEquals(ex, t)
+        1
+    }
+    assertEquals(1, get(future))
+  }
+
+  @Test(expected = classOf[TestException])
+  def recoverPartial(): Unit = {
+    val future = Future.failed(ex).recover {
+      case t: IllegalStateException => 1
+    }
+    assertEquals(1, get(future))
+  }
+
+  @Test(expected = classOf[IllegalStateException])
+  def recoverFailed(): Unit = {
+    val future = Future.failed(ex).recover {
+      case _: Throwable => throw new IllegalStateException
+    }
+    assertEquals(1, get(future))
+  }
+
+  /*** recoverWith ***/
+
+  @Test
+  def recoverWithAll(): Unit = {
+    val future = Future.failed(ex).recoverWith {
+      case t: Throwable =>
+        assertEquals(ex, t)
+        Future.successful(1)
+    }
+    assertEquals(1, get(future))
+  }
+
+  @Test(expected = classOf[IllegalStateException])
+  def recoverWithFailed(): Unit = {
+    val future = Future.failed(ex).recoverWith {
+      case _: Throwable => throw new IllegalStateException
+    }
+    assertEquals(1, get(future))
+  }
+}

--- a/future-scala/src/test/scala/io/trane/future/scala/TestException.scala
+++ b/future-scala/src/test/scala/io/trane/future/scala/TestException.scala
@@ -1,0 +1,3 @@
+package io.trane.future.scala
+
+class TestException extends RuntimeException


### PR DESCRIPTION
### Problem

Recover functions in scala futures does not handle partial functions well

### Solution

- use convenient transform in recover
- modify onException block with isDefinedAt & exp handler in recoverWith

### Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/traneio/future/blob/master/CONTRIBUTING.md)
- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
